### PR TITLE
Averlyth/navigation wip

### DIFF
--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -29,6 +29,7 @@ function NewScene(scriptPath)
     -- the script is made up of individual "events"
     -- events are defined in scriptevents.lua
     LoadScript(self, scriptPath)
+    self.currentEventIndex = 1
 
     -- run a function definition defined in the script
     self.runDefinition = function (self, defName, loc)
@@ -53,6 +54,7 @@ function NewScene(scriptPath)
 
         while #self.events >= 1 and not self.events[1]:update(self, dt) do
             table.remove(self.events, 1)
+            self.currentEventIndex = self.currentEventIndex + 1
         end
 
         self.charAnimIndex = self.charAnimIndex + dt*5

--- a/code/drawutils.lua
+++ b/code/drawutils.lua
@@ -1,0 +1,184 @@
+function DrawCenteredRectangle(options)
+    local borderSize = options.borderSize or 2
+    local borderColorAlpha = options.borderColorAlpha or {1, 1, 1, 1}
+    local colorAlpha = options.colorAlpha or {0.169, 0.526, 0.722}
+
+    local buttons = options.buttons or {}
+    local title = options.title
+    local titleHeight = options.titleHeight or 30
+
+    local width = options.width
+    local height = options.height
+    local topLeftX = (love.graphics.getWidth() - width)/2
+    local topLeftY = (love.graphics.getHeight() - height)/2
+
+
+    -- Shift the box down a little to account for the tab
+    if title then
+        height = height - titleHeight
+        topLeftY = topLeftY + titleHeight
+    end
+
+    if borderSize > 0 then
+        love.graphics.setColor(unpack(borderColorAlpha))
+        love.graphics.rectangle(
+            "fill",
+            topLeftX - borderSize,
+            topLeftY - borderSize,
+            width + (2 * borderSize),
+            height + (2 * borderSize)
+        )
+    end
+
+    love.graphics.setColor(unpack(colorAlpha))
+    love.graphics.rectangle(
+        "fill",
+        topLeftX,
+        topLeftY,
+        width,
+        height
+    )
+
+    if title then
+        local titleColorAlpha = options.titleColorAlpha or {1, 1, 1, 1}
+        local titleWidth = options.titleWidth or 180
+        local titlePadding = options.titlePadding or 5
+        local titleSlantWidth = options.titleSlantWidth or 20
+
+        if borderSize > 0 then
+            -- Title tab border
+            love.graphics.setColor(unpack(borderColorAlpha))
+            love.graphics.polygon(
+                "fill",
+                topLeftX - borderSize,
+                topLeftY - titleHeight - borderSize,
+                topLeftX + titleWidth + borderSize,
+                topLeftY - titleHeight - borderSize,
+                topLeftX + titleWidth + titleSlantWidth + borderSize,
+                topLeftY,
+                topLeftX - borderSize,
+                topLeftY
+            )
+        end
+
+        -- Title tab background
+        love.graphics.setColor(unpack(colorAlpha))
+        love.graphics.polygon(
+            "fill",
+            topLeftX,
+            topLeftY - titleHeight,
+            topLeftX + titleWidth,
+            topLeftY - titleHeight,
+            topLeftX + titleWidth + titleSlantWidth,
+            topLeftY,
+            topLeftX,
+            topLeftY
+        )
+
+        -- Title tab text
+        love.graphics.setColor(unpack(titleColorAlpha))
+        love.graphics.print(title, topLeftX + titlePadding, topLeftY - titleHeight + titlePadding - 3, 0, 2, 2)
+    end
+
+    if #buttons > 0 then
+        local buttonColorAlpha = options.buttonColorAlpha or {0, 0, 0, 1}
+        local buttonTabColorAlpha = options.buttonTabColorAlpha or {1, 1, 1, 1}
+        local buttonKeyColorAlpha = options.buttonKeyColorAlpha or {1, 1, 1, 1}
+        local buttonKeyBackgroundColorAlpha = options.buttonKeyBackgroundColorAlpha or {0.169, 0.526, 0.722}
+        local buttonPadding = options.buttonPadding or 30
+        local buttonSlantWidth = options.buttonSlantWidth or 30
+        local buttonTabHeight = options.buttonHeight or 30
+        local buttonTabWidth = options.buttonTabWidth or 0
+        local buttonTextPadding = options.buttonTextPadding or 5
+
+        -- Approximate the width we'll need to display all the buttons
+        -- Eventually this could just be an asset
+        if buttonTabWidth == 0 then
+            for i=1, #buttons do
+                buttonTabWidth = buttonTabWidth +
+                    (buttonPadding * 2) +
+                    #(buttons[i].key) +
+                    #(buttons[i].title) +
+                    (buttonTextPadding * 4)
+            end
+
+            -- If there's only one button, we don't need extra padding
+            -- on the right
+            if #buttons > 2 then
+                buttonTabWidth = buttonTabWidth + buttonPadding
+            end
+        end
+
+
+        local bottomRightX = topLeftX + width
+        local bottomRightY = topLeftY + height
+
+        -- Button tab background
+        love.graphics.setColor(unpack(buttonTabColorAlpha))
+        love.graphics.polygon(
+            "fill",
+            bottomRightX - buttonTabWidth,
+            bottomRightY - buttonTabHeight,
+            bottomRightX,
+            bottomRightY - buttonTabHeight,
+            bottomRightX,
+            bottomRightY,
+            bottomRightX - buttonTabWidth - buttonSlantWidth,
+            bottomRightY
+        )
+
+        local lastX = bottomRightX - buttonTabWidth
+        for i=1, #buttons do
+            local keyLen = #(buttons[i].key)
+            local keyX = lastX + (buttonPadding * (i - 1)) + buttonTextPadding
+            local keyY = bottomRightY - buttonTabHeight + buttonTextPadding
+            local keyHeight = buttonTabHeight - (buttonTextPadding * 2)
+            local keyWidth = keyLen > 1 and (#(buttons[i].key) * 10) or keyHeight
+
+            -- Button key indicator
+            love.graphics.setColor(unpack(buttonKeyBackgroundColorAlpha))
+            love.graphics.rectangle(
+                "fill",
+                keyX,
+                keyY,
+                keyWidth,
+                keyHeight,
+                2,
+                2
+            )
+
+            -- Button key text
+            love.graphics.setColor(unpack(buttonKeyColorAlpha))
+            love.graphics.print(buttons[i].key, keyX + (keyLen > 1 and buttonTextPadding or (keyWidth / 2 - 4)), keyY + 2, 0, 1, 1)
+
+            -- Button command text
+            love.graphics.setColor(unpack(buttonColorAlpha))
+            love.graphics.print(buttons[i].title, keyX + keyWidth + buttonTextPadding, keyY + 2, 0, 1, 1)
+
+            -- Keep track of where this button ended so we know where to start
+            lastX = keyX + keyWidth + (#(buttons[i].title) * 5)
+        end
+    end
+end
+
+function DrawPauseScreen()
+    -- Add a light overlay
+    love.graphics.setColor(1, 1, 1, 0.3)
+    love.graphics.rectangle("fill", 0, 0, love.graphics.getWidth(), love.graphics.getHeight())
+
+    -- Add the settings box with a 2px white outline
+    DrawCenteredRectangle({
+        width = love.graphics.getWidth() * 3/5,
+        height = love.graphics.getHeight() - 120,
+        buttons = {
+            {
+                title = "Back",
+                key = "Esc"
+            },
+        },
+    })
+
+    -- Temporary text where the settings should go
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.print("THE GAME IS PAUSED", love.graphics.getWidth()/3 + 15, 120, 0, 2, 2)
+end

--- a/code/drawutils.lua
+++ b/code/drawutils.lua
@@ -161,7 +161,9 @@ function DrawCenteredRectangle(options)
     end
 end
 
-function DrawPauseScreen()
+-- TODO: This matches the Switch UI but not the DS UI, and should be updated
+-- after the art team has established the look
+function DrawPauseScreen(self)
     -- Add a light overlay
     love.graphics.setColor(1, 1, 1, 0.3)
     love.graphics.rectangle("fill", 0, 0, love.graphics.getWidth(), love.graphics.getHeight())
@@ -181,4 +183,40 @@ function DrawPauseScreen()
     -- Temporary text where the settings should go
     love.graphics.setColor(1, 1, 1)
     love.graphics.print("THE GAME IS PAUSED", love.graphics.getWidth()/3 + 15, 120, 0, 2, 2)
+
+    -- Temporary(?) tools for easier developing/testing
+    love.graphics.print("Scene Script - navigate with arrow keys", 240, 220, 0, 1, 1)
+    local boxWidth = love.graphics.getWidth() * 3/5 - 70
+    local boxHeight = 400
+    love.graphics.setColor(0.5, 0.5, 0.5)
+    love.graphics.rectangle(
+        "fill",
+        240,
+        240,
+        boxWidth,
+        boxHeight
+    )
+
+    -- Only show up to 10 events for them to go back and forth between
+    love.graphics.setColor(1, 1, 1)
+
+    local firstIndex = NavigationIndex > 5 and (NavigationIndex - 5) or 1
+    local displayedIndex = 1
+    for i=firstIndex, firstIndex + 9 do
+        if i < #CurrentScene.sceneScript then
+            local label = i
+            for j=1, #CurrentScene.sceneScript[i].lineParts do
+                label = label.." "..CurrentScene.sceneScript[i].lineParts[j]
+            end
+
+            if i == NavigationIndex then
+                love.graphics.setColor(0.98, 0.82, 0.38)
+            else
+                love.graphics.setColor(1, 1, 1)
+            end
+
+            love.graphics.print(label, 245, 250 + 40 * (displayedIndex - 1), 0, 1, 1)
+            displayedIndex = displayedIndex + 1
+        end
+    end
 end

--- a/code/scriptloader.lua
+++ b/code/scriptloader.lua
@@ -1,9 +1,11 @@
 function LoadScript(scene, scriptPath)
     scene.events = {}
+    scene.sceneScript = {}
     scene.definitions = {}
     scene.type = ""
 
     local events = scene.events
+    local sceneScript = scene.sceneScript
     local definitions = {}
 
     local queuedSpeak = nil
@@ -29,7 +31,7 @@ function LoadScript(scene, scriptPath)
                         table.insert(crossExaminationQueue, lineParts[i])
                     end
                 else
-                    table.insert(events, NewCrossExaminationEvent(crossExaminationQueue))
+                    AddToStack(events, sceneScript, NewCrossExaminationEvent(crossExaminationQueue), lineParts)
                     crossExaminationQueue = nil
                 end
 
@@ -42,7 +44,7 @@ function LoadScript(scene, scriptPath)
                         table.insert(choiceQueue, lineParts[i])
                     end
                 else
-                    table.insert(events, NewChoiceEvent(choiceQueue))
+                    AddToStack(events, sceneScript, NewChoiceEvent(choiceQueue), lineParts)
                     choiceQueue = nil
                 end
 
@@ -55,7 +57,7 @@ function LoadScript(scene, scriptPath)
                         table.insert(fakeChoiceQueue, lineParts[i])
                     end
                 else
-                    table.insert(events, NewFakeChoiceEvent(fakeChoiceQueue))
+                    AddToStack(events, sceneScript, NewFakeChoiceEvent(fakeChoiceQueue), lineParts)
                     fakeChoiceQueue = nil
                 end
 
@@ -68,7 +70,7 @@ function LoadScript(scene, scriptPath)
                         table.insert(invMenuQueue, lineParts[i])
                     end
                 else
-                    table.insert(events, NewInvestigationMenuEvent(invMenuQueue))
+                    AddToStack(events, sceneScript, NewInvestigationMenuEvent(invMenuQueue), lineParts)
                     invMenuQueue = nil
                 end
 
@@ -81,7 +83,7 @@ function LoadScript(scene, scriptPath)
                         table.insert(examinationQueue, lineParts[i])
                     end
                 else
-                    table.insert(events, NewExamineEvent(examinationQueue))
+                    AddToStack(events, sceneScript, NewExamineEvent(examinationQueue), lineParts)
                     examinationQueue = nil
                 end
 
@@ -89,28 +91,28 @@ function LoadScript(scene, scriptPath)
             end
 
             if canExecuteLine and queuedSpeak ~= nil then
-                table.insert(events, NewSpeakEvent(queuedSpeak[1], lineParts[1], queuedSpeak[2], queuedSpeak[3]))
+                AddToStack(events, sceneScript, NewSpeakEvent(queuedSpeak[1], lineParts[1], queuedSpeak[2], queuedSpeak[3]), {"queuedSpeak "..queuedSpeak[1], unpack(lineParts)})
                 queuedSpeak = nil
 
                 canExecuteLine = false
             end
 
             if canExecuteLine and queuedThink ~= nil then
-                table.insert(events, NewThinkEvent(queuedThink[1], lineParts[1], queuedThink[2], queuedThink[3]))
+                AddToStack(events, sceneScript, NewThinkEvent(queuedThink[1], lineParts[1], queuedThink[2], queuedThink[3]), {"queuedThink "..queuedThink[1], unpack(lineParts)})
                 queuedThink = nil
 
                 canExecuteLine = false
             end
 
             if canExecuteLine and queuedTypewriter ~= nil then
-                table.insert(events, NewTypeWriterEvent(lineParts[1]))
+                AddToStack(events, sceneScript, NewTypeWriterEvent(lineParts[1]), {"queuedTypewriter", unpack(lineParts)})
                 queuedTypewriter = nil
 
                 canExecuteLine = false
             end
 
             if canExecuteLine and evidenceAddQueue ~= nil then
-                table.insert(events, NewAddToCourtRecordAnimationEvent(lineParts[1], evidenceAddQueue[1]))
+                AddToStack(events, sceneScript, NewAddToCourtRecordAnimationEvent(lineParts[1], evidenceAddQueue[1]), {"evidenceAddQueue "..evidenceAddQueue[1], unpack(lineParts)})
                 evidenceAddQueue = nil
 
                 canExecuteLine = false
@@ -118,23 +120,23 @@ function LoadScript(scene, scriptPath)
 
             if canExecuteLine then
                 if lineParts[1] == "CHARACTER_INITIALIZE" then
-                    table.insert(events, NewCharInitEvent(lineParts[2], lineParts[3], lineParts[4]))
+                    AddToStack(events, sceneScript, NewCharInitEvent(lineParts[2], lineParts[3], lineParts[4]), lineParts)
                 end
                 if lineParts[1] == "CHARACTER_LOCATION" then
-                    table.insert(events, NewCharLocationEvent(lineParts[2], lineParts[3]))
+                    AddToStack(events, sceneScript, NewCharLocationEvent(lineParts[2], lineParts[3]), lineParts)
                 end
                 if lineParts[1] == "EVIDENCE_INITIALIZE" then
-                    table.insert(events, NewEvidenceInitEvent(lineParts[2], lineParts[3], lineParts[4], lineParts[5]))
+                    AddToStack(events, sceneScript, NewEvidenceInitEvent(lineParts[2], lineParts[3], lineParts[4], lineParts[5]), lineParts)
                 end
                 if lineParts[1] == "COURT_RECORD_ADD" then
-                    table.insert(events, NewCourtRecordAddEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewCourtRecordAddEvent(lineParts[2]), lineParts)
                 end
 
                 if lineParts[1] == "SET_SCENE_TYPE" then
                     scene.type = lineParts[2]
                 end
                 if lineParts[1] == "END_SCENE" then
-                    table.insert(events, NewSceneEndEvent())
+                    AddToStack(events, sceneScript, NewSceneEndEvent(), lineParts)
                 end
 
                 if lineParts[1] == "DEFINE" then
@@ -145,52 +147,52 @@ function LoadScript(scene, scriptPath)
                     events = scene.events
                 end
                 if lineParts[1] == "JUMP" then
-                    table.insert(events, NewClearExecuteDefinitionEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewClearExecuteDefinitionEvent(lineParts[2]), lineParts)
                 end
 
                 if lineParts[1] == "JUMPCUT" then
-                    table.insert(events, NewCutToEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewCutToEvent(lineParts[2]), lineParts)
                 end
                 if lineParts[1] == "POSE" then
-                    table.insert(events, NewPoseEvent(lineParts[2], lineParts[3]))
+                    AddToStack(events, sceneScript, NewPoseEvent(lineParts[2], lineParts[3]), lineParts)
                 end
                 if lineParts[1] == "ANIMATION" then
                     if #lineParts == 4 then
-                        table.insert(events, NewAnimationEvent(lineParts[2], lineParts[3], lineParts[4]))
+                        AddToStack(events, sceneScript, NewAnimationEvent(lineParts[2], lineParts[3], lineParts[4]), lineParts)
                     else
-                        table.insert(events, NewAnimationEvent(lineParts[2], lineParts[3]))
+                        AddToStack(events, sceneScript, NewAnimationEvent(lineParts[2], lineParts[3]), lineParts)
                     end
                 end
                 if lineParts[1] == "PLAY_MUSIC" then
-                    table.insert(events, NewPlayMusicEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewPlayMusicEvent(lineParts[2]), lineParts)
                 end
                 if lineParts[1] == "STOP_MUSIC" then
-                    table.insert(events, NewStopMusicEvent())
+                    AddToStack(events, sceneScript, NewStopMusicEvent(), lineParts)
                 end
                 if lineParts[1] == "ISSUE_PENALTY" then
-                    table.insert(events, NewIssuePenaltyEvent())
+                    AddToStack(events, sceneScript, NewIssuePenaltyEvent(), lineParts)
                 end
                 if lineParts[1] == "GAME_OVER" then
-                    table.insert(events, NewGameOverEvent())
+                    AddToStack(events, sceneScript, NewGameOverEvent(), lineParts)
                 end
 
                 if lineParts[1] == "OBJECTION" then
-                    table.insert(events, NewObjectionEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewObjectionEvent(lineParts[2]), lineParts)
                 end
                 if lineParts[1] == "HOLD_IT" then
-                    table.insert(events, NewHoldItEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewHoldItEvent(lineParts[2]), lineParts)
                 end
                 if lineParts[1] == "WIDESHOT" then
-                    table.insert(events, NewWideShotEvent())
+                    AddToStack(events, sceneScript, NewWideShotEvent(), lineParts)
                 end
                 if lineParts[1] == "GAVEL" then
-                    table.insert(events, NewGavelEvent())
+                    AddToStack(events, sceneScript, NewGavelEvent(), lineParts)
                 end
                 if lineParts[1] == "FADE_TO_BLACK" then
-                    table.insert(events, NewFadeToBlackEvent())
+                    AddToStack(events, sceneScript, NewFadeToBlackEvent(), lineParts)
                 end
                 if lineParts[1] == "SCREEN_SHAKE" then
-                    table.insert(events, NewScreenShakeEvent())
+                    AddToStack(events, sceneScript, NewScreenShakeEvent(), lineParts)
                 end
 
                 if lineParts[1] == "CROSS_EXAMINATION" then
@@ -210,12 +212,12 @@ function LoadScript(scene, scriptPath)
                 end
 
                 if lineParts[1] == "SET_FLAG" then
-                    table.insert(events, NewSetFlagEvent(lineParts[2], lineParts[3]))
+                    AddToStack(events, sceneScript, NewSetFlagEvent(lineParts[2], lineParts[3]), lineParts)
                 end
                 if lineParts[1] == "IF"
                 and lineParts[3] == "IS"
                 and lineParts[5] == "THEN" then
-                    table.insert(events, NewIfEvent(lineParts[2], lineParts[4], lineParts[6]))
+                    AddToStack(events, sceneScript, NewIfEvent(lineParts[2], lineParts[4], lineParts[6]), lineParts)
                 end
 
                 if lineParts[1] == "SPEAK" then
@@ -225,11 +227,11 @@ function LoadScript(scene, scriptPath)
                     queuedThink = {lineParts[2], "literal", nil}
                 end
                 if lineParts[1] == "SPEAK_FROM" then
-                    table.insert(events, NewCutToEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewCutToEvent(lineParts[2]), {"SPEAK_FROM", unpack(lineParts)})
                     queuedSpeak = {lineParts[2], "location", lineParts[3]}
                 end
                 if lineParts[1] == "THINK_FROM" then
-                    table.insert(events, NewCutToEvent(lineParts[2]))
+                    AddToStack(events, sceneScript, NewCutToEvent(lineParts[2]), {"THINK_FROM", unpack(lineParts)})
                     queuedThink = {lineParts[2], "location", nil}
                 end
                 if lineParts[1] == "TYPEWRITER" then
@@ -434,4 +436,19 @@ function NewEvidenceInitEvent(name, externalName, info, file)
     end
 
     return self
+end
+
+function AddToStack(events, sceneScript, event, lineParts)
+    -- This is used by the engine to see what event should
+    -- be run right now
+    table.insert(events, event)
+
+    -- Save just enough info for us to return to this
+    -- state if we choose to skip around the game
+    local eventContext = {
+        lineParts = lineParts,
+        event = event
+    }
+
+    table.insert(sceneScript, #events, eventContext)
 end

--- a/main.lua
+++ b/main.lua
@@ -38,6 +38,7 @@ function love.load(arg)
         if arg[argIndex] == "skip" then
             for i=1, tonumber(arg[argIndex+1]) do
                 table.remove(CurrentScene.events, 1)
+                CurrentScene.currentEventIndex = CurrentScene.currentEventIndex + 1
             end
         end
         argIndex = argIndex + 1
@@ -79,7 +80,17 @@ end
 -- basic pause functionality
 function love.keypressed(key)
     if key == "escape" then
+        NavigationIndex = CurrentScene.currentEventIndex
         game_paused = not game_paused
+    elseif game_paused then
+        -- Let the user navigate
+        if key == "up" and NavigationIndex > 1 then
+            NavigationIndex = NavigationIndex - 1
+        elseif key == "down" and NavigationIndex < #CurrentScene.sceneScript then
+            NavigationIndex = NavigationIndex + 1
+        elseif key == "return" then
+            -- TODO: Implement some sort of navigation tool
+        end
     end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,7 @@ require "code/investigationscriptevents"
 require "code/utils"
 require "code/assets"
 require "code/controlscriptevents"
+require "code/drawutils"
 
 function love.load(arg)
     love.window.setMode(GraphicsWidth()*4, GraphicsHeight()*4, {})
@@ -100,12 +101,7 @@ function love.draw()
     end
     love.graphics.setColor(1,1,1)
 
-    -- Added pause, additional cleaner graphics can be added in the future
-    if game_paused then 
-        love.graphics.rectangle( "line", 30, 30, love.graphics.getWidth() - 60, love.graphics.getHeight() - 60 )
-        love.graphics.print("THE GAME IS PAUSED", love.graphics.getWidth()/3, love.graphics.getHeight()/2, 0, 2, 2)
-    else
-        love.graphics.draw(
+    love.graphics.draw(
         Renderable, 
         dx*love.graphics.getWidth()/GraphicsWidth(),
         dy*love.graphics.getHeight()/GraphicsHeight(), 
@@ -113,5 +109,10 @@ function love.draw()
         love.graphics.getWidth()/GraphicsWidth(), 
         love.graphics.getHeight()/GraphicsHeight()
     )
+
+    -- Added pause, additional cleaner graphics can be added in the future
+    if game_paused then
+        DrawPauseScreen()
     end
+
 end


### PR DESCRIPTION
Sets up a settings menu that includes the script of the scene currently being run for reference.

Next step for this branch was to support being able to select a line to load the game at, but looks like that'll require a little more thinking, since the line itself isn't enough information (e.g. the location or music may have been defined many lines earlier, and we don't want to just power through all the events until you get to the one you want)