### PR TITLE
Court record animation also adds the evidence, and includes "added" text

### DIFF
--- a/code/scriptevents.lua
+++ b/code/scriptevents.lua
@@ -194,11 +194,11 @@ function NewTypeWriterEvent(text)
     return self
 end
 
-function NewAddToCourtRecordAnimationEvent(text, evidence)
+function NewAddToCourtRecordAnimationEvent(evidence)
     local self = {}
-    self.text = text
     self.textScroll = 1
     self.evidence = evidence
+    self.text = self.evidence.." added to#the Court Record."
     self.wasPressing = true
 
     self.update = function (self, scene, dt)

--- a/code/scriptloader.lua
+++ b/code/scriptloader.lua
@@ -238,7 +238,8 @@ function LoadScript(scene, scriptPath)
                     queuedTypewriter = {}
                 end
                 if lineParts[1] == "COURT_RECORD_ADD_ANIMATION" then
-                    evidenceAddQueue = {lineParts[2]}
+                    AddToStack(events, sceneScript, NewCourtRecordAddEvent(lineParts[2]), lineParts)
+                    AddToStack(events, sceneScript, NewAddToCourtRecordAnimationEvent(lineParts[2]), lineParts)
                 end
             end
         end

--- a/scripts/e1s2.script
+++ b/scripts/e1s2.script
@@ -347,9 +347,7 @@ SPEAK_FROM COURT_JUDGE
     "I see... the court accepts it into evidence."
 
 EVIDENCE_INITIALIZE Statue "Statue" "A statue of The Thinker" evidence/thinker.png
-COURT_RECORD_ADD Statue
 COURT_RECORD_ADD_ANIMATION Statue
-    "Statue added to#the Court Record"
 
 SPEAK_FROM COURT_ASSISTANT
     "Wright..."
@@ -437,9 +435,7 @@ SPEAK_FROM COURT_PROSECUTION
     "According to this, she was in Paris until the day before she died."
 
 EVIDENCE_INITIALIZE Passport "Passport" "Arrived home from Paris on 7/30" evidence/passport.png
-COURT_RECORD_ADD Passport
 COURT_RECORD_ADD_ANIMATION Passport
-    "Passport added to#the Court Record"
 
 SPEAK_FROM COURT_JUDGE
     "Hmm... Indeed, she appears to have returned the day before the murder."


### PR DESCRIPTION
Makes COURT_RECORD_ADD_ANIMATION do what COURT_RECORD_ADD does, just with the animation at the end, so in the script we don't have to write both for it to add it and do the animation. Also puts "added to the court record." directly into the code.