### PR TITLE
added a debug option to the config.lua file and also to a startup args

### DIFF
--- a/code/scriptevents.lua
+++ b/code/scriptevents.lua
@@ -1,3 +1,5 @@
+require "config"
+
 function NewCharLocationEvent(name, location)
     local self = {}
     self.name = name
@@ -95,6 +97,9 @@ function NewSpeakEvent(who, text, locorlit, color)
 
         local lastScroll = self.textScroll
         local scrollSpeed = TextScrollSpeed
+        if controls.debug then 
+            scrollSpeed = scrollSpeed*8
+        end
         if love.keyboard.isDown("lshift") then
             scrollSpeed = scrollSpeed*8
         end

--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,11 @@ controls = {
     press_right = "right"; -- courtscene.lua
     press_left = "left"; -- courtscene.lua
     
-
+    --[[
+        setting this to true speeds up the scrollSpeed without needing to hold down "lshift"
+        this can also be set by running the startup command of `love . debug`
+    ]]
+    debug = false -- scriptevents.lua
 }
 
 dimensions = {

--- a/main.lua
+++ b/main.lua
@@ -37,6 +37,9 @@ function love.load(arg)
                 CurrentScene.currentEventIndex = CurrentScene.currentEventIndex + 1
             end
         end
+        if arg[argIndex] == "debug" then
+            controls.debug = true
+        end
         argIndex = argIndex + 1
     end
 end


### PR DESCRIPTION
This adds a `debug` variable that can be set in the config.lua file which overrides the scrollSpeed by a factor of 8 (if you hold `lshift` it goes up by a factor of 16`.

You can also pass it as a startup arg with `love . debug` instead of modifying the config file

I'll update the wiki with the new args once we merge this 