### PR TITLE
Usernameisinuse/text color

### DIFF
--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -277,36 +277,44 @@ function NewScene(scriptPath)
                             coloredTable = coloredLine3
                         end
 
-                        local char = string.sub(lineTable[i], i,i)
+                        if string.match(lineTable[i], "0") then
 
-                        --[[
-                        The way love.graphics.print() works is you can give it a
-                        table in the format of {colorTable,string,colorTable,string,...}
-                        and it will print it with the colors corresponding to the
-                        strings. This first line is just supposed to check if this
-                        is the first charcter, and if so, just add the regular color
-                        to the table to begin with, but for some reason if you
-                        active this, it will just print the color codes as their text.
-                        ]]
-                        --[[
-                        if j == 1 then
-                            table.insert(coloredTable,self.textColor)
-                        end
-                        ]]
+                            local char = string.sub(lineTable[i], j,j)
 
-                        if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
-                            table.insert(coloredTable,string)
-                            table.insert(coloredTable,self.textColor)
-                        elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                            table.insert(coloredTable,string)
-                            local tempColor = {1,0,0}
-                            table.insert(coloredTable,tempColor)
-                        else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
-                            string = string..char
-                        end
+                            --[[
+                            The way love.graphics.print() works is you can give it a
+                            table in the format of {colorTable,string,colorTable,string,...}
+                            and it will print it with the colors corresponding to the
+                            strings. This first line is just supposed to check if this
+                            is the first charcter, and if so, just add the regular color
+                            to the table to begin with, but for some reason if you
+                            active this, it will just print the color codes as their text.
+                            ]]
+                            ---[[
+                            if j == 1 then
+                                table.insert(coloredTable,self.textColor)
+                            end
+                            --]]
 
-                        if j == #lineTable[i] then -- If it's the end of the line, add the string to the table, always ends on a string
-                            table.insert(coloredTable,string)
+                            if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
+                                table.insert(coloredTable,string)
+                                string = ""
+                                table.insert(coloredTable,self.textColor)
+                            elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                local tempColor = {1,0,0}
+                                table.insert(coloredTable,tempColor)
+                            else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
+                                string = string..char
+                            end
+
+                            if j == #lineTable[i] then -- If it's the end of the line, add the string to the table, always ends on a string
+                                table.insert(coloredTable,string)
+                                string = ""
+                            end
+                        else
+                            table.insert(coloredTable,lineTable[i])
                         end
                     end
                 end

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -223,6 +223,7 @@ function NewScene(scriptPath)
                 local sidePadding = 20
                 local wrapWidth = self.textBoxSprite:getWidth() - (sidePadding * 2)
 
+                --
                 for i=1, #self.fullText do
                     local char = string.sub(self.fullText, i,i)
 
@@ -255,9 +256,32 @@ function NewScene(scriptPath)
                     lineTable[lineTableIndex] = lineTable[lineTableIndex] .. char
                 end
 
+                local coloredLine1 = {}
+                local coloredLine2 = {}
+                local coloredLine3 = {}
+
                 for i=1, #lineTable do
-                    love.graphics.print(lineTable[i], 8, GraphicsHeight()-60 + (i-1)*16)
+
+                    for a=1, #i do
+                        if a == "0" then
+                            local colored == nil
+                        elseif a == "1" then
+                            local colored == true
+                            local color = {1,0,0,1}  
+                        end
+
+                        if colored == true then
+
+                        end
+                    end
                 end
+
+                local coloredLineTable = {coloredLine1,coloredLine2,coloredLine3}
+
+                for i=1, #lineTable do
+                    love.graphics.print(unpack(coloredLineTable[1]), 8, GraphicsHeight()-60 + (i-1)*16)
+                end
+            -- Centered Text
             else
                 local lineTable = {"", "", ""}
                 local lineIndex = 1
@@ -284,6 +308,8 @@ function NewScene(scriptPath)
                         lineTableFull[lineIndex] = lineTableFull[lineIndex] .. char
                     end
                 end
+
+
 
                 for i=1, #lineTable do
                     local xText = GraphicsWidth()/2 - GameFont:getWidth(lineTableFull[i])/2

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -259,29 +259,70 @@ function NewScene(scriptPath)
                 local coloredLine1 = {}
                 local coloredLine2 = {}
                 local coloredLine3 = {}
+                local string = ""
+
+                --[[
+                Supposed to iterate over each line, and then each character in
+                each line to formulate the colored table to be sent to print.
+                Doesn't work currently, Alex can't figure out why.
+                ]]
 
                 for i=1, #lineTable do
-
-                    for a=1, #i do
-                        if a == "0" then
-                            local colored == nil
-                        elseif a == "1" then
-                            local colored == true
-                            local color = {1,0,0,1}  
+                    for j=1, #lineTable[i] do
+                        if i == 1 then
+                            coloredTable = coloredLine1
+                        elseif i == 2 then
+                            coloredTable = coloredLine2
+                        elseif i == 3 then
+                            coloredTable = coloredLine3
                         end
 
-                        if colored == true then
+                        local char = string.sub(lineTable[i], i,i)
 
+                        --[[
+                        The way love.graphics.print() works is you can give it a
+                        table in the format of {colorTable,string,colorTable,string,...}
+                        and it will print it with the colors corresponding to the
+                        strings. This first line is just supposed to check if this
+                        is the first charcter, and if so, just add the regular color
+                        to the table to begin with, but for some reason if you
+                        active this, it will just print the color codes as their text.
+                        ]]
+                        --[[
+                        if j == 1 then
+                            table.insert(coloredTable,self.textColor)
+                        end
+                        ]]
+
+                        if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
+                            table.insert(coloredTable,string)
+                            table.insert(coloredTable,self.textColor)
+                        elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                            table.insert(coloredTable,string)
+                            local tempColor = {1,0,0}
+                            table.insert(coloredTable,tempColor)
+                        else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
+                            string = string..char
+                        end
+
+                        if j == #lineTable[i] then -- If it's the end of the line, add the string to the table, always ends on a string
+                            table.insert(coloredTable,string)
                         end
                     end
                 end
 
+                -- If these lines are empty, adds a blank string to ensure it doesn't crash
+                if coloredLine2[1] == nil then coloredLine2[1] = "" end
+                if coloredLine3[1] == nil then coloredLine3[1] = "" end
+
+                -- Combine the colored line tables into a single colored line table
                 local coloredLineTable = {coloredLine1,coloredLine2,coloredLine3}
 
+                -- Prints
                 for i=1, #lineTable do
-                    love.graphics.print(unpack(coloredLineTable[1]), 8, GraphicsHeight()-60 + (i-1)*16)
+                    love.graphics.print(unpack(coloredLineTable[i]), 8, GraphicsHeight()-60 + (i-1)*16)
                 end
-            -- Centered Text
+            -- Centered Text, untouched by inline colored text
             else
                 local lineTable = {"", "", ""}
                 local lineIndex = 1

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -261,7 +261,7 @@ function NewScene(scriptPath)
                 local coloredLine3 = {}
                 local string = ""
 
-                -- Supports colored text within lines, currently does not function over multiple lines
+                -- Supports colored text within lines, currently does not function with normal numbers in the script
                 for i=1, #lineTable do
                     for j=1, #lineTable[i] do
                         if i == 1 then
@@ -273,45 +273,55 @@ function NewScene(scriptPath)
                         end
 
                         local char = string.sub(lineTable[i], j,j)
-                        if string.gmatch(lineTable[i], "0") then
 
-                            -- Sets the default color at the beginning
+                        -- Sets the color at the beginning of the line
+                        if i == 1 then
                             if j == 1 then
                                 table.insert(coloredTable,self.textColor)
                             end
-
-                            if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
-                                table.insert(coloredTable,string)
-                                string = ""
+                        elseif j == 1 then
+                            if colored then -- Continues the color onto a newline
+                                table.insert(coloredTable,tempColor)
+                            else
                                 table.insert(coloredTable,self.textColor)
-                            elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                                table.insert(coloredTable,string)
-                                string = ""
-                                local tempColor = {1,0,0}
-                                table.insert(coloredTable,tempColor)
-                            elseif char == "2" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                                table.insert(coloredTable,string)
-                                string = ""
-                                local tempColor = {0,1,0}
-                                table.insert(coloredTable,tempColor)
-                            elseif char == "3" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                                table.insert(coloredTable,string)
-                                string = ""
-                                local tempColor = {0,0,1}
-                                table.insert(coloredTable,tempColor)
-                            else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
-                                string = string..char
                             end
+                        end
 
-                            if j == #lineTable[i] then -- If it's the end of the line, add the string to the table, always ends on a string
-                                table.insert(coloredTable,string)
-                                string = ""
-                            end
-                        else
-                            table.insert(coloredTable,char)
+                        if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
+                            table.insert(coloredTable,string)
+                            string = ""
+                            table.insert(coloredTable,self.textColor)
+                            colored = nil
+                        elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                            table.insert(coloredTable,string)
+                            string = ""
+                            tempColor = {1,0,0}
+                            table.insert(coloredTable,tempColor)
+                            colored = true
+                        elseif char == "2" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                            table.insert(coloredTable,string)
+                            string = ""
+                            tempColor = {0,1,0}
+                            table.insert(coloredTable,tempColor)
+                            colored = true
+                        elseif char == "3" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                            table.insert(coloredTable,string)
+                            string = ""
+                            tempColor = {0,0,1}
+                            table.insert(coloredTable,tempColor)
+                            colored = true
+                        else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
+                            string = string..char
+                        end
+
+                        if j == #lineTable[i] then -- If it's the end of the line, add the string to the table, always ends on a string
+                            table.insert(coloredTable,string)
+                            string = ""
                         end
                     end
                 end
+
+                colored = nil
 
                 -- If these lines are empty, adds a blank string to ensure it doesn't crash
                 if coloredLine2[1] == nil then coloredLine2[1] = "" end

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -277,9 +277,8 @@ function NewScene(scriptPath)
                             coloredTable = coloredLine3
                         end
 
-                        if string.match(lineTable[i], "0") then
-
-                            local char = string.sub(lineTable[i], j,j)
+                        local char = string.sub(lineTable[i], j,j)
+                        if string.gmatch(lineTable[i], "0") then
 
                             --[[
                             The way love.graphics.print() works is you can give it a
@@ -305,6 +304,16 @@ function NewScene(scriptPath)
                                 string = ""
                                 local tempColor = {1,0,0}
                                 table.insert(coloredTable,tempColor)
+                            elseif char == "2" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                local tempColor = {0,1,0}
+                                table.insert(coloredTable,tempColor)
+                            elseif char == "3" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                local tempColor = {0,0,1}
+                                table.insert(coloredTable,tempColor)
                             else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
                                 string = string..char
                             end
@@ -314,7 +323,7 @@ function NewScene(scriptPath)
                                 string = ""
                             end
                         else
-                            table.insert(coloredTable,lineTable[i])
+                            table.insert(coloredTable,char)
                         end
                     end
                 end
@@ -328,7 +337,7 @@ function NewScene(scriptPath)
 
                 -- Prints
                 for i=1, #lineTable do
-                    love.graphics.print(unpack(coloredLineTable[i]), 8, GraphicsHeight()-60 + (i-1)*16)
+                    love.graphics.print(coloredLineTable[i], 8, GraphicsHeight()-60 + (i-1)*16)
                 end
             -- Centered Text, untouched by inline colored text
             else

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -260,8 +260,9 @@ function NewScene(scriptPath)
                 local coloredLine2 = {}
                 local coloredLine3 = {}
                 local string = ""
+                colorSetup = {}
 
-                -- Supports colored text within lines, currently does not function with normal numbers in the script
+                -- Supports colored text within lines
                 for i=1, #lineTable do
                     for j=1, #lineTable[i] do
                         if i == 1 then
@@ -287,30 +288,40 @@ function NewScene(scriptPath)
                             end
                         end
 
-                        if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
-                            table.insert(coloredTable,string)
-                            string = ""
-                            table.insert(coloredTable,self.textColor)
-                            colored = nil
-                        elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                            table.insert(coloredTable,string)
-                            string = ""
-                            tempColor = {1,0,0}
-                            table.insert(coloredTable,tempColor)
-                            colored = true
-                        elseif char == "2" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                            table.insert(coloredTable,string)
-                            string = ""
-                            tempColor = {0,1,0}
-                            table.insert(coloredTable,tempColor)
-                            colored = true
-                        elseif char == "3" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
-                            table.insert(coloredTable,string)
-                            string = ""
-                            tempColor = {0,0,1}
-                            table.insert(coloredTable,tempColor)
-                            colored = true
-                        else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
+                        -- Checks for script color setup character "%"
+                        if char == "%" then
+                            colorSetup = {}
+                            colorSetup["s"] = j+1
+                        end
+
+                        if colorSetup["s"] == j then
+                            if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
+                                table.insert(coloredTable,string)
+                                string = ""
+                                table.insert(coloredTable,self.textColor)
+                                colored = nil
+                            elseif char == "1" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                tempColor = {1,0,0}
+                                table.insert(coloredTable,tempColor)
+                                colored = true
+                            elseif char == "2" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                tempColor = {0,1,0}
+                                table.insert(coloredTable,tempColor)
+                                colored = true
+                            elseif char == "3" then -- Start of a colored segment, add the string before the new color to the table, then add the new color
+                                table.insert(coloredTable,string)
+                                string = ""
+                                tempColor = {0,0,1}
+                                table.insert(coloredTable,tempColor)
+                                colored = true
+                            else -- If not the start or end of a colored segment, simply add the character to the string to be added to the table
+                                string = string..char
+                            end
+                        else
                             string = string..char
                         end
 
@@ -321,7 +332,9 @@ function NewScene(scriptPath)
                     end
                 end
 
+                -- Resets things between speak events
                 colored = nil
+                colorSetup = {}
 
                 -- If these lines are empty, adds a blank string to ensure it doesn't crash
                 if coloredLine2[1] == nil then coloredLine2[1] = "" end

--- a/code/courtscene.lua
+++ b/code/courtscene.lua
@@ -261,12 +261,7 @@ function NewScene(scriptPath)
                 local coloredLine3 = {}
                 local string = ""
 
-                --[[
-                Supposed to iterate over each line, and then each character in
-                each line to formulate the colored table to be sent to print.
-                Doesn't work currently, Alex can't figure out why.
-                ]]
-
+                -- Supports colored text within lines, currently does not function over multiple lines
                 for i=1, #lineTable do
                     for j=1, #lineTable[i] do
                         if i == 1 then
@@ -280,20 +275,10 @@ function NewScene(scriptPath)
                         local char = string.sub(lineTable[i], j,j)
                         if string.gmatch(lineTable[i], "0") then
 
-                            --[[
-                            The way love.graphics.print() works is you can give it a
-                            table in the format of {colorTable,string,colorTable,string,...}
-                            and it will print it with the colors corresponding to the
-                            strings. This first line is just supposed to check if this
-                            is the first charcter, and if so, just add the regular color
-                            to the table to begin with, but for some reason if you
-                            active this, it will just print the color codes as their text.
-                            ]]
-                            ---[[
+                            -- Sets the default color at the beginning
                             if j == 1 then
                                 table.insert(coloredTable,self.textColor)
                             end
-                            --]]
 
                             if char == "0" then --End of a colored segment, add the colored string to the table, then add the normal color back
                                 table.insert(coloredTable,string)

--- a/scripts/e1s1.script
+++ b/scripts/e1s1.script
@@ -166,7 +166,7 @@ SPEAK Phoenix
     "Larry Butz... my best friend since grade school."
 
 SPEAK Phoenix
-    "Our school had a saying: $q1When something smells, it's usually the Butz.0$q"
+    "Our school had a saying: $q%1When something smells, it's usually the Butz.%0$q"
 
 SPEAK Phoenix
     "In the 23 years I've known him, it's usually been true."

--- a/scripts/e1s1.script
+++ b/scripts/e1s1.script
@@ -135,7 +135,7 @@ SPEAK Butz
     "Aww, Nick, ya gotta tell me! Who took my baby away!?"
 
 THINK Phoenix
-    "(Hmm... The person responsible for your girlfriend's#death?)"
+    "(Hmm... The person responsible for your girlfriend's death?)"
 
 THINK Phoenix
     "(The newspapers say it was you...)"

--- a/scripts/e1s1.script
+++ b/scripts/e1s1.script
@@ -29,7 +29,7 @@ SPEAK Mia
     "Wright!"
 
 SPEAK Phoenix
-    "Oh, h-hiya, Chief."
+    "Oh, h-hiya, 1Chief.0"
 
 SPEAK Mia
     "Whew!#I'm glad I made it on time."

--- a/scripts/e1s1.script
+++ b/scripts/e1s1.script
@@ -29,7 +29,7 @@ SPEAK Mia
     "Wright!"
 
 SPEAK Phoenix
-    "Oh, h-hiya, 1Chief.0"
+    "Oh, h-hiya, 1Ch02ie03f.0"
 
 SPEAK Mia
     "Whew!#I'm glad I made it on time."

--- a/scripts/e1s1.script
+++ b/scripts/e1s1.script
@@ -29,7 +29,7 @@ SPEAK Mia
     "Wright!"
 
 SPEAK Phoenix
-    "Oh, h-hiya, 1Ch02ie03f.0"
+    "Oh, h-hiya, Chief."
 
 SPEAK Mia
     "Whew!#I'm glad I made it on time."
@@ -166,7 +166,7 @@ SPEAK Phoenix
     "Larry Butz... my best friend since grade school."
 
 SPEAK Phoenix
-    "Our school had a saying: $qWhen something smells, it's usually the Butz.$q"
+    "Our school had a saying: $q1When something smells, it's usually the Butz.0$q"
 
 SPEAK Phoenix
     "In the 23 years I've known him, it's usually been true."

--- a/scripts/e1s2.script
+++ b/scripts/e1s2.script
@@ -91,7 +91,7 @@ SPEAK_FROM COURT_JUDGE
     "This test will consist of a few simple questions. Answer them clearly and concisely."
 
 SPEAK_FROM COURT_JUDGE
-    "Please state the name of 1the defendant0 in this case."
+    "Please state the name of %1the defendant%0 in this case."
 
 DEFINE DefendantPhoenix
     SPEAK_FROM COURT_DEFENSE
@@ -200,13 +200,13 @@ SPEAK_FROM COURT_ASSISTANT
     "Look, the defendant's name is listed in the Court Record."
 
 SPEAK_FROM COURT_ASSISTANT
-    "Just touch the 1Court Record button0 to check it at anytime, okay?"
+    "Just touch the %1Court Record button%0 to check it at anytime, okay?"
 
 SPEAK_FROM COURT_ASSISTANT
     "Remember to check it often.  Do it for me, please.  I'm begging you."
 
 SPEAK_FROM COURT_JUDGE
-    "Let's hear your answer.  Who is the 1victim0 in this case?"
+    "Let's hear your answer.  Who is the %1victim%0 in this case?"
 
 DEFINE VictimMia
     SPEAK_FROM COURT_DEFENSE
@@ -359,7 +359,7 @@ SPEAK_FROM COURT_ASSISTANT
     "That evidence is the only ammunition you have in court."
 
 SPEAK_FROM COURT_ASSISTANT
-    "Touch the 1Court Record button0 to check the Court Record frequently."
+    "Touch the %1Court Record button%0 to check the Court Record frequently."
 
 SPEAK_FROM COURT_JUDGE
     "Mr. Payne, the prosecution may call its first witness."
@@ -465,7 +465,7 @@ SPEAK_FROM COURT_PROSECUTION
     "We can clearly see what kind of woman this Ms. Stone was."
 
 SPEAK_FROM COURT_PROSECUTION
-    "Tell me, Mr. Butz, 1what do you think of her now?0"
+    "Tell me, Mr. Butz, %1what do you think of her now?%0"
 
 SPEAK_FROM COURT_ASSISTANT
     "Wright..."
@@ -592,7 +592,7 @@ DEFINE AnswerHonestly
         "Lying?"
 
     SPEAK_FROM COURT_PROSECUTION
-        "The prosecution would like to call a 1witness0 who can prove Mr. Butz is lying."
+        "The prosecution would like to call a %1witness%0 who can prove Mr. Butz is lying."
 END_DEFINE
 
 DEFINE StopHim

--- a/scripts/e1s2.script
+++ b/scripts/e1s2.script
@@ -91,7 +91,7 @@ SPEAK_FROM COURT_JUDGE
     "This test will consist of a few simple questions. Answer them clearly and concisely."
 
 SPEAK_FROM COURT_JUDGE
-    "Please state the name of the defendant in this case."
+    "Please state the name of 1the defendant0 in this case."
 
 DEFINE DefendantPhoenix
     SPEAK_FROM COURT_DEFENSE
@@ -200,13 +200,13 @@ SPEAK_FROM COURT_ASSISTANT
     "Look, the defendant's name is listed in the Court Record."
 
 SPEAK_FROM COURT_ASSISTANT
-    "Just touch the Court Record button to check it at anytime, okay?"
+    "Just touch the 1Court Record button0 to check it at anytime, okay?"
 
 SPEAK_FROM COURT_ASSISTANT
     "Remember to check it often.  Do it for me, please.  I'm begging you."
 
 SPEAK_FROM COURT_JUDGE
-    "Let's hear your answer.  Who is the victim in this case?"
+    "Let's hear your answer.  Who is the 1victim0 in this case?"
 
 DEFINE VictimMia
     SPEAK_FROM COURT_DEFENSE
@@ -359,7 +359,7 @@ SPEAK_FROM COURT_ASSISTANT
     "That evidence is the only ammunition you have in court."
 
 SPEAK_FROM COURT_ASSISTANT
-    "Touch the Court Record button to check the Court Record frequently."
+    "Touch the 1Court Record button0 to check the Court Record frequently."
 
 SPEAK_FROM COURT_JUDGE
     "Mr. Payne, the prosecution may call its first witness."
@@ -465,7 +465,7 @@ SPEAK_FROM COURT_PROSECUTION
     "We can clearly see what kind of woman this Ms. Stone was."
 
 SPEAK_FROM COURT_PROSECUTION
-    "Tell me, Mr. Butz, what do you think of her now?"
+    "Tell me, Mr. Butz, 1what do you think of her now?0"
 
 SPEAK_FROM COURT_ASSISTANT
     "Wright..."
@@ -592,7 +592,7 @@ DEFINE AnswerHonestly
         "Lying?"
 
     SPEAK_FROM COURT_PROSECUTION
-        "The prosecution would like to call a witness who can prove Mr. Butz is lying."
+        "The prosecution would like to call a 1witness0 who can prove Mr. Butz is lying."
 END_DEFINE
 
 DEFINE StopHim


### PR DESCRIPTION
Allows support for color within text lines in the script by writing `%` and then a number. Right now, `1` is red, `2` is green, `3` is blue, and `0` ends the colored segment, which must be present, unless the colored segment goes til the end of the speak event. Because of the setup character, that means you can have numbers in the script without it triggering a color to appear.
Example of it in use:
![2019-09-3015-43-42](https://user-images.githubusercontent.com/49582925/65911498-bbfe8880-e39a-11e9-9ab3-7defcae505e8.gif)