### PR TITLE
Automated build generation via GitHub Actions

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -1,0 +1,32 @@
+name: Generate release
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+      
+jobs:
+  build-upload:
+    name: Generate self-contained archives
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: nhartland/love-build@v1-beta2
+      id: love-build
+      with:
+        app_name: 'Game Grumps - Joint Justice'
+        love_version: '11.3'
+    - uses: ncipollo/release-action@v1.8.6
+      with:
+        artifacts: |
+          ${{ steps.love-build.outputs.macos-filename }},
+          ${{ steps.love-build.outputs.win32-filename }},
+          ${{ steps.love-build.outputs.win64-filename }},
+          ${{ steps.love-build.outputs.love-filename }}
+        tag: "${{ github.run_number }}"
+        name: "Development release #${{ github.run_number }}"
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change automatically creates self-containing `.zip`-archives for macOS, Windows and `.love`-files for Linux.  
This eliminates the need for players to manually install LÖVE. However the current drag-and-drop startup method still works.

# How to use
With this change, GitHub watches for pushes to the `master`-branch of this repository. No extra steps are necessary.
For every commit, a GitHub Release is automatically created:
![image](https://user-images.githubusercontent.com/1689033/126745161-768ad565-25a7-4bd6-93bf-5ca1df65fc9b.png)

Inside each release, standalone downloads for each platform can be found:
![image](https://user-images.githubusercontent.com/1689033/126745224-db1448d1-649b-492d-a9b1-72ecafcb471a.png)
![image](https://user-images.githubusercontent.com/1689033/126745721-7d9e5678-a432-427e-94c9-cb6be4a657e9.png)

# Side-notes
As this creates a new executable file, most OSes treat them as new apps and present a note for the first few startups of a release. For Windows this ends as soon as the Microsoft servers rank an executable as safe which usually takes a couple of days. 
![image](https://user-images.githubusercontent.com/1689033/126745490-d55fbde4-e63d-4340-bcf0-87b5c83dd243.png)
I think macOS has a similar solution, however I don't have a device to test it on.

---

Haven't worked with LÖVE so I just wanted to play around with this repo a bit a figured this might make things easier for new players. If this is a change you're not currently interested in, that's cool too! :)